### PR TITLE
feat: DataManager 추가

### DIFF
--- a/RandomMusic/RandomMusic/Data/DataManager.swift
+++ b/RandomMusic/RandomMusic/Data/DataManager.swift
@@ -1,6 +1,16 @@
 import Foundation
 import CoreData
 
+struct SongDTO {
+    let title: String
+    let album: String
+    let artist: String
+    let genre: String
+    let id: Int
+    let streamUrl: String
+    let thumbnail: Data?
+}
+
 final class DataManager {
     static let shared = DataManager()
 
@@ -38,10 +48,33 @@ final class DataManager {
             print(error)
         }
     }
+    
+    /// 음악 데이터를 영구적으로 저장합니다.
+    /// - Parameter song: 저장할 음악 데이터를 받습니다.
+    func insertSongData(from song: SongDTO) {
+        let newSong = Song(context: mainContext)
+        newSong.title = song.title
+        newSong.album = song.album
+        newSong.artist = song.artist
+        newSong.genre = song.genre
+        newSong.id = Int64(song.id)
+        newSong.streamUrl = song.streamUrl
+        newSong.insertDate = .now
 
-	// TODO: Insert 정의
+        // 이미지 데이터는 용량이 크기 때문에 디렉토리에 따로 저장해두고 해당 디렉토리를 가르키는 URL만 따로 CoreData에 저장합니다.
+        let thumbnailFileName = String(newSong.id) + ".png"
+        if let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent(thumbnailFileName) {
+            do {
+                try song.thumbnail?.write(to: url)
+                newSong.thumbnail = thumbnailFileName
+                saveContext()
+            } catch {
+                print(error)
+            }
+        }
+    }
 
-    /// Context에 저장된 데이터를 영구적으로 저장합니다.
+    /// Context에 임시 저장된 데이터를 영구적으로 저장합니다.
     func saveContext() {
         let context = persistentContainer.viewContext
 

--- a/RandomMusic/RandomMusic/Data/DataManager.swift
+++ b/RandomMusic/RandomMusic/Data/DataManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreData
 
-struct SongDTO {
+struct SongEntity {
     let title: String
     let album: String
     let artist: String
@@ -51,7 +51,7 @@ final class DataManager {
     
     /// 음악 데이터를 영구적으로 저장합니다.
     /// - Parameter song: 저장할 음악 데이터를 받습니다.
-    func insertSongData(from song: SongDTO) {
+    func insertSongData(from song: SongEntity) {
         let newSong = Song(context: mainContext)
         newSong.title = song.title
         newSong.album = song.album
@@ -77,6 +77,33 @@ final class DataManager {
         deleteImageFile(name: deletedSong.thumbnail)
         mainContext.delete(deletedSong)
         saveContext()
+    }
+
+    // TODO: 알고리즘에 따라서 변경되는 수치는 바뀔 수 있음.
+    /// 장르별 추천 수치를 변경합니다.
+    /// - Parameters:
+    ///   - genre: 음악의 장르를 받습니다. (String)
+    ///   - upper: 추천하면 양수, 비추천하면 음수를 받습니다.
+    func recommendGenre(to genre: String, upper: Int) {
+        var genreCounts = UserDefaults.standard.dictionary(forKey: "Genre") as? [String: Int] ?? [:]
+
+        if genreCounts[genre, default: 0] + upper < 0 {
+            genreCounts[genre, default: 0] = 1
+        } else {
+            genreCounts[genre, default: 0] += upper
+        }
+
+        UserDefaults.standard.setValue(genreCounts, forKey: "Genre")
+    }
+    
+    /// 장르별 추천 수치를 모두 반환합니다.
+    /// - Returns: 장르별 추천 수치를 배열로 반환합니다.
+    func fetchAllGenre() -> [(genre: String, count: Int)] {
+        if let genreCounts = UserDefaults.standard.dictionary(forKey: "Genre") as? [String: Int] {
+			return Array(genreCounts).sorted { $0.value > $1.value }.map { (genre: $0.key, count: $0.value) }
+        }
+
+        return []
     }
 
     /// Context에서 변경된 데이터를 영구적으로 저장합니다.

--- a/RandomMusic/RandomMusic/Data/DataManager.swift
+++ b/RandomMusic/RandomMusic/Data/DataManager.swift
@@ -4,25 +4,44 @@ import CoreData
 final class DataManager {
     static let shared = DataManager()
 
-    private init() {}
+    let mainContext: NSManagedObjectContext
+    let persistentContainer: NSPersistentContainer
 
-    var mainContext: NSManagedObjectContext {
-        return persistentContainer.viewContext
-    }
+    let fetchedResults: NSFetchedResultsController<Song>
 
-    // MARK: - Core Data stack
-    lazy var persistentContainer: NSPersistentContainer = {
+    private init() {
         let container = NSPersistentContainer(name: "RandomMusic")
 
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+        container.loadPersistentStores { storeDescription, error in
             if let error = error as NSError? {
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
-        })
-        return container
-    }()
+        }
 
-    // MARK: - Core Data Saving support
+        persistentContainer = container
+        mainContext = container.viewContext
+
+        let request = Song.fetchRequest()
+        let sortedByDate = NSSortDescriptor(keyPath: \Song.insertDate, ascending: false)
+        request.sortDescriptors = [sortedByDate]
+
+        fetchedResults = NSFetchedResultsController(
+            fetchRequest: request,
+            managedObjectContext: mainContext,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
+
+        do {
+            try fetchedResults.performFetch()
+        } catch {
+            print(error)
+        }
+    }
+
+	// TODO: Insert 정의
+
+    /// Context에 저장된 데이터를 영구적으로 저장합니다.
     func saveContext() {
         let context = persistentContainer.viewContext
 

--- a/RandomMusic/RandomMusic/Data/DataManager.swift
+++ b/RandomMusic/RandomMusic/Data/DataManager.swift
@@ -79,23 +79,21 @@ final class DataManager {
         saveContext()
     }
 
-    // TODO: 알고리즘에 따라서 변경되는 수치는 바뀔 수 있음.
-    /// 장르별 추천 수치를 변경합니다.
+    // TODO: 알고리즘에 따라 수치는 변경될 수 있습니다.
+    /// 장르별 추천 수치를 조정합니다.
     /// - Parameters:
-    ///   - genre: 음악의 장르를 받습니다. (String)
-    ///   - upper: 추천하면 양수, 비추천하면 음수를 받습니다.
-    func recommendGenre(to genre: String, upper: Int) {
+    ///   - genre: 음악 장르를 받습니다. (예: "rock", "ballad")
+    ///   - delta: 추천 시 양수, 비추천 시 음수 값을 받습니다.
+    func adjustGenreScore(for genre: String, by delta: Int) {
         var genreCounts = UserDefaults.standard.dictionary(forKey: "Genre") as? [String: Int] ?? [:]
 
-        if genreCounts[genre, default: 0] + upper < 0 {
-            genreCounts[genre, default: 0] = 1
-        } else {
-            genreCounts[genre, default: 0] += upper
-        }
+        let current = genreCounts[genre] ?? 0
+        let updated = max(current + delta, 1)
+        genreCounts[genre] = updated
 
-        UserDefaults.standard.setValue(genreCounts, forKey: "Genre")
+        UserDefaults.standard.set(genreCounts, forKey: "Genre")
     }
-    
+
     /// 장르별 추천 수치를 모두 반환합니다.
     /// - Returns: 장르별 추천 수치를 배열로 반환합니다.
     func fetchAllGenre() -> [(genre: String, count: Int)] {


### PR DESCRIPTION
### 설명
---

DataManager를 통해서 CoreData에 영구적으로 저장하고 UserDefaults에 저장할 수 있습니다.

- SongEntity를 통해서 음악을 영구적으로 저장 및 삭제합니다.
    - 테이블뷰로 쉽게 읽고 데이터의 변화에 대응하기 위해 `NSFetchedResultsController`를 사용합니다.

- 장르별 추천 수는 UserDefaults를 활용합니다.

```swift
// TODO: 알고리즘에 따라 수치는 변경될 수 있습니다.
/// 장르별 추천 수치를 조정합니다.
func adjustGenreScore(for genre: String, by delta: Int) {
    var genreCounts = UserDefaults.standard.dictionary(forKey: "Genre") as? [String: Int] ?? [:]

    let current = genreCounts[genre] ?? 0
    let updated = max(current + delta, 1)
    genreCounts[genre] = updated

    UserDefaults.standard.set(genreCounts, forKey: "Genre")
}

/// 장르별 추천 수치를 모두 반환합니다.
func fetchAllGenre() -> [(genre: String, count: Int)] {
    if let genreCounts = UserDefaults.standard.dictionary(forKey: "Genre") as? [String: Int] {
        return Array(genreCounts).sorted { $0.value > $1.value }.map { (genre: $0.key, count: $0.value) }
    }
    return []
}
```