### PR TITLE
feat: 화면 연결 로직 적용

### DIFF
--- a/RandomMusic/RandomMusic/App/AppDelegate.swift
+++ b/RandomMusic/RandomMusic/App/AppDelegate.swift
@@ -4,11 +4,8 @@ import CoreData
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-
         return true
     }
-
-    
 
     // MARK: UISceneSession Lifecycle
 

--- a/RandomMusic/RandomMusic/App/AppDelegate.swift
+++ b/RandomMusic/RandomMusic/App/AppDelegate.swift
@@ -4,9 +4,11 @@ import CoreData
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+
         return true
     }
+
+    
 
     // MARK: UISceneSession Lifecycle
 

--- a/RandomMusic/RandomMusic/App/SceneDelegate.swift
+++ b/RandomMusic/RandomMusic/App/SceneDelegate.swift
@@ -5,10 +5,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
+
+        let isFirstLaunch = !UserDefaults.standard.bool(forKey: "HasLaunchedBefore")
+
+        showOnboardingScreen()
+
+        if isFirstLaunch {
+            UserDefaults.standard.set(true, forKey: "HasLaunchedBefore")
+        } else {
+            //showMainScreen()
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -42,5 +49,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
 
+    private func showOnboardingScreen() {
+        let storyboard = UIStoryboard(name: "Onboarding", bundle: nil)
+
+        guard let onboardingVC = storyboard.instantiateInitialViewController() else {
+            return
+        }
+
+        if let window = UIApplication.shared.windows.first {
+            window.rootViewController = onboardingVC
+            window.makeKeyAndVisible()
+        }
+    }
 }
 

--- a/RandomMusic/RandomMusic/App/SceneDelegate.swift
+++ b/RandomMusic/RandomMusic/App/SceneDelegate.swift
@@ -7,14 +7,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let _ = (scene as? UIWindowScene) else { return }
 
-        let isFirstLaunch = !UserDefaults.standard.bool(forKey: "HasLaunchedBefore")
-
-        showOnboardingScreen()
+        let isFirstLaunch = !UserDefaults.standard.bool(forKey: "isOnboardingCompleted")
 
         if isFirstLaunch {
-            UserDefaults.standard.set(true, forKey: "HasLaunchedBefore")
+            showOnboardingScreen()
         } else {
-            //showMainScreen()
+            showMainScreen()
         }
     }
 
@@ -52,12 +50,25 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     private func showOnboardingScreen() {
         let storyboard = UIStoryboard(name: "Onboarding", bundle: nil)
 
-        guard let onboardingVC = storyboard.instantiateInitialViewController() else {
+        guard let vc = storyboard.instantiateInitialViewController() else {
             return
         }
 
         if let window = UIApplication.shared.windows.first {
-            window.rootViewController = onboardingVC
+            window.rootViewController = vc
+            window.makeKeyAndVisible()
+        }
+    }
+
+    private func showMainScreen() {
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+
+        guard let vc = storyboard.instantiateInitialViewController() else {
+            return
+        }
+
+        if let window = UIApplication.shared.windows.first {
+            window.rootViewController = vc
             window.makeKeyAndVisible()
         }
     }

--- a/RandomMusic/RandomMusic/Network/NetworkManager.swift
+++ b/RandomMusic/RandomMusic/Network/NetworkManager.swift
@@ -58,11 +58,6 @@ class NetworkManager {
         return asset
     }
 
-
-
-
-
-
     // 랜덤 음악 가져오기
     private func fetchRandomMusic(genre: Genre? = nil) async throws -> SongResponse {
         var urlString = "\(baseURL)/api/music/random"

--- a/RandomMusic/RandomMusic/Storyboard/Base.lproj/Main.storyboard
+++ b/RandomMusic/RandomMusic/Storyboard/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oUJ-Ad-HvN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oUJ-Ad-HvN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -19,10 +19,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="60" translatesAutoresizingMaskIntoConstraints="NO" id="csQ-jE-PJx">
-                                <rect key="frame" x="0.0" y="138" width="393" height="714"/>
+                                <rect key="frame" x="0.0" y="79" width="393" height="773"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="1uq-HC-Gcy">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="554"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="613"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalCentering" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="KkE-tO-Z9x">
                                                 <rect key="frame" x="20" y="0.0" width="353" height="60.666666666666664"/>
@@ -45,7 +45,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Singer" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i0s-Ti-8Zv">
-                                                                <rect key="frame" x="0.0" y="40.333333333333343" width="49" height="20.333333333333329"/>
+                                                                <rect key="frame" x="0.0" y="40.333333333333329" width="49" height="20.333333333333329"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -63,14 +63,14 @@
                                                 </subviews>
                                             </stackView>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zyz-oi-m8T">
-                                                <rect key="frame" x="60" y="112.66666666666666" width="273" height="273"/>
+                                                <rect key="frame" x="60" y="132.33333333333337" width="273" height="273"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="zyz-oi-m8T" secondAttribute="height" multiplier="1:1" id="mbS-4V-ZHA"/>
                                                 </constraints>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="uqY-cv-jzx">
-                                                <rect key="frame" x="20" y="437.66666666666663" width="353" height="30"/>
+                                                <rect key="frame" x="20" y="477" width="353" height="30"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yTE-gk-zc6">
                                                         <rect key="frame" x="0.0" y="0.0" width="0.0" height="30"/>
@@ -93,7 +93,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="idR-k5-etR">
-                                                <rect key="frame" x="29" y="519.66666666666663" width="335" height="34.333333333333371"/>
+                                                <rect key="frame" x="29" y="578.66666666666663" width="335" height="34.333333333333371"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IGc-Tg-0S2">
                                                         <rect key="frame" x="0.0" y="0.0" width="51.666666666666664" height="34.333333333333336"/>
@@ -128,6 +128,7 @@
                                                         <buttonConfiguration key="configuration" style="plain" image="speedometer" catalog="system"/>
                                                         <connections>
                                                             <action selector="speedTapped:" destination="oUJ-Ad-HvN" eventType="touchUpInside" id="eTa-fw-2sC"/>
+                                                            <segue destination="8wS-cc-rHn" kind="presentation" id="1Hl-QS-Y5D"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>
@@ -143,7 +144,7 @@
                                         </constraints>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vzb-Vd-KfB">
-                                        <rect key="frame" x="0.0" y="614" width="393" height="100"/>
+                                        <rect key="frame" x="0.0" y="673" width="393" height="100"/>
                                         <color key="backgroundColor" name="AccentColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="100" id="yOy-ej-ans"/>
@@ -180,6 +181,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cLW-Kc-rBY" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="977.86259541984725" y="17.605633802816904"/>
+        </scene>
+        <!--PlayListView-->
+        <scene sceneID="dUg-a0-S37">
+            <objects>
+                <viewControllerPlaceholder storyboardIdentifier="PlayListView" storyboardName="PlayListView" referencedIdentifier="PlayListView" id="8wS-cc-rHn" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ZMz-Mx-vTZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1829" y="18"/>
         </scene>
     </scenes>
     <resources>

--- a/RandomMusic/RandomMusic/Storyboard/Base.lproj/Main.storyboard
+++ b/RandomMusic/RandomMusic/Storyboard/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
         <!--Main View Controller-->
         <scene sceneID="O4Q-Cx-Ami">
             <objects>
-                <viewController id="oUJ-Ad-HvN" customClass="MainViewController" customModule="RandomMusic" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="MainVC" id="oUJ-Ad-HvN" customClass="MainViewController" customModule="RandomMusic" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="KHS-me-IdP">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -162,6 +162,7 @@
                             <constraint firstAttribute="trailing" secondItem="csQ-jE-PJx" secondAttribute="trailing" id="hl8-qb-Bbt"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="Y2J-Hm-K2a"/>
                     <connections>
                         <outlet property="backwardButton" destination="Yxe-Hu-wav" id="OUf-uy-0Ve"/>
                         <outlet property="currentTimeLabel" destination="yTE-gk-zc6" id="QMN-8K-KSt"/>
@@ -180,7 +181,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cLW-Kc-rBY" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="977.86259541984725" y="17.605633802816904"/>
+            <point key="canvasLocation" x="1904.5801526717557" y="17.605633802816904"/>
         </scene>
         <!--PlayListView-->
         <scene sceneID="dUg-a0-S37">
@@ -188,7 +189,7 @@
                 <viewControllerPlaceholder storyboardIdentifier="PlayListView" storyboardName="PlayListView" referencedIdentifier="PlayListView" id="8wS-cc-rHn" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ZMz-Mx-vTZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1829" y="18"/>
+            <point key="canvasLocation" x="2754.1984732824426" y="17.605633802816904"/>
         </scene>
     </scenes>
     <resources>

--- a/RandomMusic/RandomMusic/Storyboard/Onboarding.storyboard
+++ b/RandomMusic/RandomMusic/Storyboard/Onboarding.storyboard
@@ -105,7 +105,6 @@
                                 </buttonConfiguration>
                                 <connections>
                                     <action selector="confirmButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="uCn-vE-OLK"/>
-                                    <segue destination="1V8-Vb-8lp" kind="show" id="8m3-AW-uDN"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -141,16 +140,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-16.030534351145036" y="3.5211267605633805"/>
-        </scene>
-        <!--MainVC-->
-        <scene sceneID="mls-Lf-eOo">
-            <objects>
-                <viewControllerPlaceholder storyboardIdentifier="MainVC" storyboardName="Main" referencedIdentifier="MainVC" id="1V8-Vb-8lp" sceneMemberID="viewController">
-                    <navigationItem key="navigationItem" id="GfB-ea-2S4"/>
-                </viewControllerPlaceholder>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="5Mc-2z-X7b" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="721" y="4"/>
         </scene>
     </scenes>
     <resources>

--- a/RandomMusic/RandomMusic/Storyboard/Onboarding.storyboard
+++ b/RandomMusic/RandomMusic/Storyboard/Onboarding.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r6K-9O-ZPP">
-                                <rect key="frame" x="290" y="53" width="83" height="35"/>
+                                <rect key="frame" x="290" y="-6" width="83" height="35"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="35" id="92w-sA-NFw"/>
                                     <constraint firstAttribute="width" constant="83" id="cUZ-qz-Ukk"/>
@@ -30,28 +30,14 @@
                                     <action selector="skipButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="9Cz-VK-u1m"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lif-Wb-wUa">
-                                <rect key="frame" x="0.0" y="777" width="393" height="75"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="75" id="4Ll-B8-SWk"/>
-                                </constraints>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="확인">
-                                    <color key="baseForegroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <color key="baseBackgroundColor" red="0.78823529411764703" green="0.90980392156862744" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
-                                </buttonConfiguration>
-                                <connections>
-                                    <action selector="confirmButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="uCn-vE-OLK"/>
-                                </connections>
-                            </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="선호하는 장르를 선택해주세요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EZp-oy-bQC">
-                                <rect key="frame" x="84" y="168" width="225" height="23"/>
+                                <rect key="frame" x="84" y="109" width="225" height="23"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="LqK-CZ-59o">
-                                <rect key="frame" x="50" y="281" width="293" height="406"/>
+                                <rect key="frame" x="50" y="222" width="293" height="465"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="apc-LM-Ite">
                                     <size key="itemSize" width="128" height="128"/>
@@ -107,6 +93,21 @@
                                     <outlet property="delegate" destination="Y6W-OH-hqX" id="xeD-zl-n8S"/>
                                 </connections>
                             </collectionView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lif-Wb-wUa">
+                                <rect key="frame" x="0.0" y="777" width="393" height="75"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="75" id="4Ll-B8-SWk"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="확인">
+                                    <color key="baseForegroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="baseBackgroundColor" red="0.78823529411764703" green="0.90980392156862744" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="confirmButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="uCn-vE-OLK"/>
+                                    <segue destination="1V8-Vb-8lp" kind="show" id="8m3-AW-uDN"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -140,6 +141,16 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-16.030534351145036" y="3.5211267605633805"/>
+        </scene>
+        <!--MainVC-->
+        <scene sceneID="mls-Lf-eOo">
+            <objects>
+                <viewControllerPlaceholder storyboardIdentifier="MainVC" storyboardName="Main" referencedIdentifier="MainVC" id="1V8-Vb-8lp" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="GfB-ea-2S4"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="5Mc-2z-X7b" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="721" y="4"/>
         </scene>
     </scenes>
     <resources>

--- a/RandomMusic/RandomMusic/Storyboard/PlayListView.storyboard
+++ b/RandomMusic/RandomMusic/Storyboard/PlayListView.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eLK-HM-NZt">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eLK-HM-NZt">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -196,10 +196,10 @@
         <!--Navigation Controller-->
         <scene sceneID="C5T-bD-ync">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="eLK-HM-NZt" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="PlayListView" automaticallyAdjustsScrollViewInsets="NO" id="eLK-HM-NZt" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" largeTitles="YES" id="j5f-by-1bS">
-                        <rect key="frame" x="0.0" y="118" width="393" height="96"/>
+                        <rect key="frame" x="0.0" y="59" width="393" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <navigationBarAppearance key="standardAppearance"/>
                     </navigationBar>
@@ -210,7 +210,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="j2W-KI-jn7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1239" y="5"/>
+            <point key="canvasLocation" x="1195" y="5"/>
         </scene>
     </scenes>
     <resources>
@@ -218,10 +218,10 @@
         <image name="forward.frame.fill" catalog="system" width="128" height="87"/>
         <image name="play.circle.fill" catalog="system" width="128" height="123"/>
         <namedColor name="MainColor">
-            <color red="0.78823529411764703" green="0.90980392156862744" blue="0.30980392156862746" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.78799998760223389" green="0.9100000262260437" blue="0.31000000238418579" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="secondaryLabelColor">
-            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/RandomMusic/RandomMusic/Storyboard/PlayListView.storyboard
+++ b/RandomMusic/RandomMusic/Storyboard/PlayListView.storyboard
@@ -210,7 +210,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="j2W-KI-jn7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1195" y="5"/>
+            <point key="canvasLocation" x="1181" y="5"/>
         </scene>
     </scenes>
     <resources>

--- a/RandomMusic/RandomMusic/View/ViewController/MainViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/MainViewController.swift
@@ -144,6 +144,9 @@ class MainViewController: UIViewController {
     /// 재생속도 버튼을 탭했을 때 호출됩니다.
     @IBAction func speedTapped(_ sender: UIButton) {
         // TODO: 재생속도 버튼 클릭 로직 추가
+        if let vc = storyboard?.instantiateViewController(withIdentifier: "PlayListView") {
+            present(vc, animated: true)
+        }
     }
 
     /// 재생/일시정지 버튼의 아이콘을 상태에 따라 갱신합니다.

--- a/RandomMusic/RandomMusic/View/ViewController/OnBoarding/OnBoardingViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/OnBoarding/OnBoardingViewController.swift
@@ -85,9 +85,9 @@ class OnBoardingViewController: UIViewController, UICollectionViewDataSource, UI
 
     @IBAction func confirmButtonTapped(_ sender: UIButton) {
         // 확인 버튼을 눌렀을 때
-        let mainVC = storyboard?.instantiateViewController(withIdentifier: "mainViewController") as! MainViewController
+        let mainVC = storyboard?.instantiateViewController(withIdentifier: "MainVC") as! MainViewController
         //        mainVC.selectedGenres = selectedGenres
-        present(mainVC, animated: true)
+        navigationController?.pushViewController(mainVC, animated: true)
 
         UserDefaults.standard.set(true, forKey: "isOnboardingCompleted")
     }

--- a/RandomMusic/RandomMusic/View/ViewController/OnBoarding/OnBoardingViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/OnBoarding/OnBoardingViewController.swift
@@ -76,20 +76,28 @@ class OnBoardingViewController: UIViewController, UICollectionViewDataSource, UI
 
     @IBAction func skipButtonTapped(_ sender: UIButton) {
         // 건너뛰기 버튼을 눌렀을 때
-        let mainVC = storyboard?.instantiateViewController(withIdentifier: "MainViewController") as! MainViewController
         //        mainVC.selectedGenres = []
-        present(mainVC, animated: true)
-
-        UserDefaults.standard.set(true, forKey: "isOnboardingCompleted")
+        toMainVC()
     }
 
     @IBAction func confirmButtonTapped(_ sender: UIButton) {
         // 확인 버튼을 눌렀을 때
-        let mainVC = storyboard?.instantiateViewController(withIdentifier: "MainVC") as! MainViewController
         //        mainVC.selectedGenres = selectedGenres
-        navigationController?.pushViewController(mainVC, animated: true)
+        toMainVC()
+    }
+
+    private func toMainVC() {
+        let mainStoryboard = UIStoryboard(name: "Main", bundle: nil)
+        if let mainVC = mainStoryboard.instantiateInitialViewController() {
+            if let windowScene = view.window?.windowScene,
+               let sceneDelegate = windowScene.delegate as? SceneDelegate,
+               let window = sceneDelegate.window {
+
+                window.rootViewController = mainVC
+                UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve, animations: nil)
+            }
+        }
 
         UserDefaults.standard.set(true, forKey: "isOnboardingCompleted")
     }
-
 }


### PR DESCRIPTION
## 작업
---

### Onboarding 로직
OnboardingVC에서 MainVC에 `present` 방식으로 사용하면 OnboardingVC에서 메모리 누수가 발생하는 상황이 있었습니다.
화면을 덮는 방법보다 Window를 교체하는 방법이 메모리 누수를 막을 수 있어서 해당 방법을 사용했습니다.

아래코드는 OnboardingVC 코드이며 유정님께서 참고하시면 될 거 같습니다.

```swift
@IBAction func skipButtonTapped(_ sender: UIButton) {
    // 건너뛰기 버튼을 눌렀을 때
    toMainVC()
}

@IBAction func confirmButtonTapped(_ sender: UIButton) {
    // 확인 버튼을 눌렀을 때
    toMainVC()
}

private func toMainVC() {
    let mainStoryboard = UIStoryboard(name: "Main", bundle: nil)
    if let mainVC = mainStoryboard.instantiateInitialViewController() {
        if let windowScene = view.window?.windowScene,
           let sceneDelegate = windowScene.delegate as? SceneDelegate,
           let window = sceneDelegate.window {

            window.rootViewController = mainVC
            UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve, animations: nil)
        }
    }

    UserDefaults.standard.set(true, forKey: "isOnboardingCompleted")
}
```

**스토리보드 객체를 생성하는 방식을 사용하기 때문에 따로 Storyboard Reference는 연결하지 않았습니다.**
![image](https://github.com/user-attachments/assets/3d7d8a77-2e3d-470d-b3a1-d93655ffcd4e)

### MainView <-> PlaylistView
여기는 화면이 전환되기 때문에 Storyboard Reference를 사용해서 화면 전환을 구성했습니다.

```swift
if let vc = storyboard?.instantiateViewController(withIdentifier: "PlayListView") {
    present(vc, animated: true)
}
```

![image](https://github.com/user-attachments/assets/1685193a-92ca-43bf-98e3-8093744f4821)


