### PR TITLE
feat: 이전곡/다음곡 재생 기능 추가

### DIFF
--- a/RandomMusic/RandomMusic/Util/TimeFormatter.swift
+++ b/RandomMusic/RandomMusic/Util/TimeFormatter.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// 시간 형식 변환을 담당하는 유틸리티 클래스입니다.
+struct TimeFormatter {
+    /// 시간을 "MM:SS" 형식의 문자열로 변환합니다.
+    /// - Parameter time: 초 단위 시간입니다.
+    /// - Returns: 형식화된 시간 문자열입니다.
+    static func formatTime(_ time: TimeInterval) -> String {
+        let totalSeconds = Int(time)
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+}

--- a/RandomMusic/RandomMusic/View/ViewController/Main/Base.lproj/Main.storyboard
+++ b/RandomMusic/RandomMusic/View/ViewController/Main/Base.lproj/Main.storyboard
@@ -108,6 +108,9 @@
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" image="backward.frame.fill" catalog="system" title=""/>
+                                                        <connections>
+                                                            <action selector="backwardTapped:" destination="oUJ-Ad-HvN" eventType="touchUpInside" id="ZWy-qN-G96"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kfD-3U-Pv5">
                                                         <rect key="frame" x="141.66666666666666" y="0.0" width="49.666666666666657" height="34.333333333333336"/>
@@ -121,6 +124,9 @@
                                                         <rect key="frame" x="211.33333333333334" y="0.0" width="52.000000000000028" height="34.333333333333336"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" image="forward.frame.fill" catalog="system"/>
+                                                        <connections>
+                                                            <action selector="forwardTapped:" destination="oUJ-Ad-HvN" eventType="touchUpInside" id="ecc-bd-prP"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YDU-yv-gk2">
                                                         <rect key="frame" x="283.33333333333331" y="0.0" width="49.666666666666686" height="34.333333333333336"/>

--- a/RandomMusic/RandomMusic/View/ViewController/Main/MainViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/Main/MainViewController.swift
@@ -138,15 +138,7 @@ class MainViewController: UIViewController {
 
     /// 재생/일시정지 버튼을 탭했을 때 호출됩니다.
     @IBAction func playPauseTapped(_ sender: UIButton) {
-        if PlayerManager.shared.isPlaying {
-            PlayerManager.shared.pause()
-        } else {
-            if PlayerManager.shared.isPlayerReady {
-                PlayerManager.shared.resume()
-            } else {
-                PlayerManager.shared.play()
-            }
-        }
+        PlayerManager.shared.togglePlayPause()
     }
 
     /// 이전 곡 버튼을 탭했을 때 호출됩니다.

--- a/RandomMusic/RandomMusic/View/ViewController/Main/MainViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/Main/MainViewController.swift
@@ -18,42 +18,75 @@ class MainViewController: UIViewController {
 
     var isDisliked = false
     var isLiked = false
-    var isPlaying = false
-    var currentSong: SongModel?
-
-    /// 재생된 곡들을 저장하는 히스토리 배열입니다.
-    var playedSongs: [SongModel] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         setupUI()
-        fetchRandomSongFromNetwork()
+        fetchRandomSong()
         bindPlayerCallbacks()
     }
 
-    /// 초기 UI 상태를 설정합니다.
+    /// 썸네일과 슬라이더의 초기 UI 상태를 설정합니다.
     private func setupUI() {
         thumbnailImageView.layer.cornerRadius = thumbnailImageView.frame.width / 2
         thumbnailImageView.clipsToBounds = true
         progressSlider.value = 0
     }
 
-    /// 네트워크로부터 랜덤 곡을 비동기적으로 가져옵니다.
-    ///
-    /// `shouldPlay`가 true인 경우, 곡 정보를 구성한 뒤 자동으로 재생을 시작합니다.
-    ///
-    /// - Parameter shouldPlay: 곡을 가져온 후 즉시 재생할지 여부입니다.
-    private func fetchRandomSongFromNetwork(shouldPlay: Bool = false) {
+    /// 재생/일시정지 버튼의 아이콘을 상태에 따라 갱신합니다.
+    private func updatePlayPauseButton() {
+        let icon = PlayerManager.shared.isPlaying ? "pause.circle.fill" : "play.circle.fill"
+        playPauseButton.setImage(UIImage(systemName: icon), for: .normal)
+    }
+
+    /// 좋아요/싫어요 버튼의 아이콘을 상태에 따라 갱신합니다.
+    private func updateLikeDislikeButtons() {
+        let likeIcon = isLiked ? "hand.thumbsup.fill" : "hand.thumbsup"
+        let dislikeIcon = isDisliked ? "hand.thumbsdown.fill" : "hand.thumbsdown"
+
+        likeButton.setImage(UIImage(systemName: likeIcon), for: .normal)
+        dislikeButton.setImage(UIImage(systemName: dislikeIcon), for: .normal)
+    }
+
+    /// AVPlayer의 시간 업데이트 및 재생 완료 콜백을 바인딩합니다.
+    private func bindPlayerCallbacks() {
+        PlayerManager.shared.onTimeUpdate = updateProgressUI
+
+        PlayerManager.shared.onPlayStateChanged = { [weak self] isPlaying in
+            self?.updatePlayPauseButton()
+        }
+
+        PlayerManager.shared.onSongChanged = { [weak self] in
+            self?.updateSongUI()
+        }
+
+        PlayerManager.shared.onNeedNewSong = { [weak self] in
+            self?.fetchRandomSong(shouldPlay: true)
+        }
+    }
+
+    private func updateProgressUI(seconds: Double) {
+        progressSlider.value = Float(seconds)
+        currentTimeLabel.text = TimeFormatter.formatTime(seconds)
+    }
+
+    private func fetchRandomSong(shouldPlay: Bool = false) {
         Task {
             do {
                 let song = try await NetworkManager.shared.getMusic()
                 await MainActor.run {
-                    playedSongs.append(song)
-                    configure(with: song)
+                    let currentPlaylist = PlayerManager.shared.playlist
+                    let newPlaylist = currentPlaylist + [song]
+                    let newIndex = currentPlaylist.count
+
+                    PlayerManager.shared.setPlaylist(newPlaylist)
+                    PlayerManager.shared.setCurrentIndex(newIndex)
+
+                    updateSongUI()
 
                     if shouldPlay {
-                        playCurrentSongIfAvailable()
+                        PlayerManager.shared.play()
                     }
                 }
             } catch {
@@ -62,67 +95,21 @@ class MainViewController: UIViewController {
         }
     }
 
-    /// 곡 정보를 UI와 슬라이더에 구성합니다.
-    ///
-    /// 썸네일 이미지, 제목, 아티스트, 슬라이더의 최대값 및 총 시간 라벨을 설정합니다.
-    /// 이 메서드는 재생을 수행하지 않으며, UI 세팅만 담당합니다.
-    ///
-    /// - Parameter song: 구성할 `SongModel` 객체입니다.
-    private func configure(with song: SongModel) {
-        currentSong = song
-        titleLabel.text = song.title
-        singerLabel.text = song.artist
-        thumbnailImageView.image = song.thumbnailData.flatMap { UIImage(data: $0) }
-
-        guard let asset = NetworkManager.shared.createAssetWithHeaders(url: song.streamUrl) else {
-            print("asset error")
+    private func updateSongUI() {
+        guard let currentSong = PlayerManager.shared.currentSong else {
+            print("No current song available")
             return
         }
 
-        PlayerManager.shared.loadDuration(with: asset) { [weak self] seconds in
+        titleLabel.text = currentSong.title
+        singerLabel.text = currentSong.artist
+        thumbnailImageView.image = currentSong.thumbnailData.flatMap { UIImage(data: $0) }
+
+        PlayerManager.shared.loadDuration() { [weak self] seconds in
             guard let self, let duration = seconds else { return }
 
             self.progressSlider.maximumValue = Float(duration)
-            self.totalTimeLabel.text = formatTime(duration)
-        }
-    }
-
-    /// 현재 곡이 유효할 경우 재생을 시작합니다.
-    ///
-    /// `currentSong`이 존재하고 스트리밍 URL이 유효한 경우 AVPlayer로 재생을 시작합니다.
-    /// 버튼 상태도 재생 중으로 갱신합니다.
-    private func playCurrentSongIfAvailable() {
-        guard let song = currentSong,
-              let asset = NetworkManager.shared.createAssetWithHeaders(url: song.streamUrl) else {
-            return
-        }
-
-        PlayerManager.shared.play(asset: asset)
-        isPlaying = true
-        updatePlayPauseButton()
-    }
-
-
-    /// AVPlayer의 콜백을 바인딩합니다.
-    ///
-    /// 재생 시간 갱신과 재생 완료 시 동작을 정의합니다.
-    /// 재생 완료 시에는 반복 모드 상태에 따라 다음 곡을 자동으로 재생할 수 있습니다.
-    private func bindPlayerCallbacks() {
-        PlayerManager.shared.onTimeUpdate = { [weak self] seconds in
-            self?.progressSlider.value = Float(seconds)
-            self?.currentTimeLabel.text = self?.formatTime(seconds)
-        }
-
-        PlayerManager.shared.onPlaybackFinished = { [weak self] in
-            guard let self else { return }
-
-            self.isPlaying = false
-            self.updatePlayPauseButton()
-
-            // 한 곡 반복이 아닐 때 랜덤 곡 재생
-            if !PlayerManager.shared.isRepeatEnabled {
-                self.fetchRandomSongFromNetwork(shouldPlay: true)
-            }
+            self.totalTimeLabel.text = TimeFormatter.formatTime(duration)
         }
     }
 
@@ -136,7 +123,8 @@ class MainViewController: UIViewController {
         toggleLikeDislike(like: false)
     }
 
-    /// 좋아요/싫어요 버튼의 아이콘을 상태에 따라 갱신합니다.
+    /// 좋아요/싫어요 상태를 전환하고 버튼을 갱신합니다.
+    /// - Parameter like: true이면 좋아요, false이면 싫어요 처리입니다.
     private func toggleLikeDislike(like: Bool) {
         if like {
             isLiked.toggle()
@@ -150,70 +138,43 @@ class MainViewController: UIViewController {
 
     /// 재생/일시정지 버튼을 탭했을 때 호출됩니다.
     @IBAction func playPauseTapped(_ sender: UIButton) {
-        defer {
-            isPlaying.toggle()
-            updatePlayPauseButton()
-        }
-
-        if isPlaying {
+        if PlayerManager.shared.isPlaying {
             PlayerManager.shared.pause()
-            return
-        }
-
-        if PlayerManager.shared.isPlayerReady {
-            PlayerManager.shared.resume()
-        } else if let song = currentSong,
-                  let asset = NetworkManager.shared.createAssetWithHeaders(url: song.streamUrl) {
-            PlayerManager.shared.play(asset: asset)
+        } else {
+            if PlayerManager.shared.isPlayerReady {
+                PlayerManager.shared.resume()
+            } else {
+                PlayerManager.shared.play()
+            }
         }
     }
 
+    /// 이전 곡 버튼을 탭했을 때 호출됩니다.
+    @IBAction func backwardTapped(_ sender: UIButton) {
+        PlayerManager.shared.moveBackward()
+    }
 
-    /// 슬라이더의 값을 변경했을 때 재생 위치를 이동합니다.
+    /// 다음 곡 버튼을 탭했을 때 호출됩니다.
+    @IBAction func forwardTapped(_ sender: UIButton) {
+        PlayerManager.shared.moveForward()
+    }
+
+    /// 슬라이더를 변경하여 재생 위치를 이동합니다.
     @IBAction func sliderValueChanged(_ sender: UISlider) {
         PlayerManager.shared.seek(to: Double(sender.value))
     }
 
-    /// 반복 버튼을 탭했을 때 호출됩니다.
+    /// 반복 버튼을 탭했을 때 반복 모드를 토글합니다.
     @IBAction func repeatTapped(_ sender: UIButton) {
-        PlayerManager.shared.isRepeatEnabled.toggle()
+        PlayerManager.shared.toggleRepeat()
         let icon = PlayerManager.shared.isRepeatEnabled ? "repeat.1.circle.fill" : "repeat.1.circle"
         repeatButton.setImage(UIImage(systemName: icon), for: .normal)
     }
 
     /// 재생속도 버튼을 탭했을 때 호출됩니다.
     @IBAction func speedTapped(_ sender: UIButton) {
-        // TODO: 재생속도 버튼 클릭 로직 추가
         if let vc = storyboard?.instantiateViewController(withIdentifier: "PlayListView") {
             present(vc, animated: true)
         }
-    }
-
-    /// 재생/일시정지 버튼의 아이콘을 상태에 따라 갱신합니다.
-    private func updatePlayPauseButton() {
-        let icon = isPlaying ? "pause.circle.fill" : "play.circle.fill"
-
-        playPauseButton.setImage(UIImage(systemName: icon), for: .normal)
-    }
-
-    /// 좋아요/싫어요 버튼의 아이콘을 상태에 따라 갱신합니다.
-    private func updateLikeDislikeButtons() {
-        let likeIcon = isLiked ? "hand.thumbsup.fill" : "hand.thumbsup"
-        let dislikeIcon = isDisliked ? "hand.thumbsdown.fill" : "hand.thumbsdown"
-
-        likeButton.setImage(UIImage(systemName: likeIcon), for: .normal)
-        dislikeButton.setImage(UIImage(systemName: dislikeIcon), for: .normal)
-    }
-
-    /// 시간을 "MM:SS" 형식의 문자열로 변환합니다.
-    ///
-    /// - Parameter time: 초 단위 시간입니다.
-    /// - Returns: 변환된 시간 문자열입니다.
-    private func formatTime(_ time: TimeInterval) -> String {
-        let totalSeconds = Int(time)
-        let minutes = totalSeconds / 60
-        let seconds = totalSeconds % 60
-
-        return String(format: "%02d:%02d", minutes, seconds)
     }
 }

--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
@@ -89,10 +89,7 @@ class PlayListViewController: UIViewController {
         player?.pause()
         player = nil
         
-        let avUrlAsset = NetworkManager.shared.createAssetWithHeaders(url: streamUrl)
-        guard let asset = avUrlAsset else { return }
-        
-        PlayerManager.shared.play(asset: asset)
+        PlayerManager.shared.play()
        
         isPlaying = false
     }


### PR DESCRIPTION
## 작업 내용
- 이전곡/다음곡 재생 기능을 추가하였습니다.
- [해당 문서](https://github.com/est-ios2-2nd-team-1/RandomMusic/blob/chore/architecture/RandomMusic/RandomMusic/Manager/PlayerManager.swift)를 참고하여, MainViewController가 PlayerManager를 외부 라이브러리처럼 사용하도록 책임을 분리한 구조로 변경하였습니다.
  - `MainViewController`: 사용자 이벤트에 따른 플레이어 동작 요청 및 UI 업데이트
  - `PlayerManager`: 재생목록 및 현재곡 관련 상태 관리, 플레이어 직접 제어

## 테스트 목록
- 재생/일시정지
- 이전곡 재생
- 다음곡 재생
- 한 곡 반복

> [!NOTE]
> 아래에 간략하게 셀프리뷰도 하였습니다.