### PR TITLE
Refactor: 초기 화면 분기 로직 수정 (OnboardingView, MainView)

### DIFF
--- a/RandomMusic/RandomMusic/App/SceneDelegate.swift
+++ b/RandomMusic/RandomMusic/App/SceneDelegate.swift
@@ -1,21 +1,24 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
     var window: UIWindow?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        guard let _ = (scene as? UIWindowScene) else { return }
-
         RemoteManager.shared.configure()
 
         let isFirstLaunch = !UserDefaults.standard.bool(forKey: "isOnboardingCompleted")
+        isFirstLaunch ? showScreen(to: "Onboarding") : showScreen(to: "Main")
+    }
 
-        if isFirstLaunch {
-            showOnboardingScreen()
-        } else {
-            showMainScreen()
+    private func showScreen(to name: String) {
+        let storyboard = UIStoryboard(name: name, bundle: nil)
+
+        guard let vc = storyboard.instantiateInitialViewController() else {
+            return
         }
+
+        window?.rootViewController = vc
+        window?.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -46,33 +49,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
 
         // Save changes in the application's managed object context when the application transitions to the background.
-    }
-
-
-    private func showOnboardingScreen() {
-        let storyboard = UIStoryboard(name: "Onboarding", bundle: nil)
-
-        guard let vc = storyboard.instantiateInitialViewController() else {
-            return
-        }
-
-        if let window = UIApplication.shared.windows.first {
-            window.rootViewController = vc
-            window.makeKeyAndVisible()
-        }
-    }
-
-    private func showMainScreen() {
-        let storyboard = UIStoryboard(name: "Main", bundle: nil)
-
-        guard let vc = storyboard.instantiateInitialViewController() else {
-            return
-        }
-
-        if let window = UIApplication.shared.windows.first {
-            window.rootViewController = vc
-            window.makeKeyAndVisible()
-        }
     }
 }
 


### PR DESCRIPTION
## 작업
---

```swift
func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
    RemoteManager.shared.configure()

    let isFirstLaunch = !UserDefaults.standard.bool(forKey: "isOnboardingCompleted")
    isFirstLaunch ? showScreen(to: "Onboarding") : showScreen(to: "Main")
}
```

아래 메소드는 멘토님께서 파라미터로 이름을 받고 리팩토링 하면 좋을 거 같다고 말씀하셔서 수정했습니다.

또한 `UIApplication.shared.windows` 가 Deprecated 되어 로직을 수정했습니다.
(GPT를 신뢰하면 안되는 이유..🥲)

### 수정 전
```swift
private func showOnboardingScreen() {
    let storyboard = UIStoryboard(name: "Onboarding", bundle: nil)

    guard let vc = storyboard.instantiateInitialViewController() else {
        return
    }

    if let window = UIApplication.shared.windows.first {
        window.rootViewController = vc
        window.makeKeyAndVisible()
    }
}

private func showMainScreen() {
    let storyboard = UIStoryboard(name: "Main", bundle: nil)

    guard let vc = storyboard.instantiateInitialViewController() else {
        return
    }

    if let window = UIApplication.shared.windows.first {
        window.rootViewController = vc
        window.makeKeyAndVisible()
    }
}
```

### 수정 후
```swift
private func showScreen(to name: String) {
    let storyboard = UIStoryboard(name: name, bundle: nil)

    guard let vc = storyboard.instantiateInitialViewController() else {
        return
    }

    window?.rootViewController = vc
    window?.makeKeyAndVisible()
}
```