### PR TITLE
Refactor: DataManager 인터페이스 변경

### DIFF
--- a/RandomMusic/RandomMusic/Data/RandomMusic.xcdatamodeld/RandomMusic.xcdatamodel/contents
+++ b/RandomMusic/RandomMusic/Data/RandomMusic.xcdatamodeld/RandomMusic.xcdatamodel/contents
@@ -15,13 +15,13 @@
         <attribute name="songId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <entity name="Song" representedClassName="Song" syncable="YES" codeGenerationType="class">
-        <attribute name="album" attributeType="String"/>
-        <attribute name="artist" attributeType="String"/>
-        <attribute name="genre" attributeType="String"/>
+        <attribute name="album" attributeType="String" defaultValueString="&quot;&quot;"/>
+        <attribute name="artist" attributeType="String" defaultValueString="&quot;&quot;"/>
+        <attribute name="genre" attributeType="String" defaultValueString="&quot;&quot;"/>
         <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="insertDate" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="streamUrl" attributeType="String"/>
+        <attribute name="streamUrl" optional="YES" attributeType="String"/>
         <attribute name="thumbnail" optional="YES" attributeType="String"/>
-        <attribute name="title" attributeType="String"/>
+        <attribute name="title" attributeType="String" defaultValueString="&quot;&quot;"/>
     </entity>
 </model>

--- a/RandomMusic/RandomMusic/Model/Song+Extension.swift
+++ b/RandomMusic/RandomMusic/Model/Song+Extension.swift
@@ -1,13 +1,13 @@
 import UIKit
 
 extension Song {
-    var thumbnailImage: UIImage? {
+    var thumbnailData: Data? {
         let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         let url = documentsDirectory.appendingPathComponent(self.thumbnail ?? "")
-        if let data = try? Data(contentsOf: url) {
-            return UIImage(data: data)
-        }
+        return try? Data(contentsOf: url)
+    }
 
-        return nil
+    func toModel() -> SongModel {
+        SongModel(from: self)
     }
 }

--- a/RandomMusic/RandomMusic/Model/SongModel.swift
+++ b/RandomMusic/RandomMusic/Model/SongModel.swift
@@ -29,7 +29,7 @@ struct SongModel {
         self.title = entity.title ?? ""
         self.album = entity.album ?? ""
         self.artist = entity.artist ?? ""
-        self.genre = entity.genre ?? ""
+        self.genre = Genre(rawValue: entity.genre ?? "")
         self.id = Int(entity.id)
         self.streamUrl = entity.streamUrl ?? ""
         self.thumbnailData = entity.thumbnailData

--- a/RandomMusic/RandomMusic/Model/SongModel.swift
+++ b/RandomMusic/RandomMusic/Model/SongModel.swift
@@ -21,4 +21,17 @@ struct SongModel {
         self.streamUrl = response.streamUrl
         self.thumbnailData = thumbnailData
     }
+
+    
+    /// 코어데이터 Song 엔티티를 SongModel 객체로 변환합니다.
+    /// - Parameter entity: Song Entity를 받습니다.
+    init(from entity: Song) {
+        self.title = entity.title ?? ""
+        self.album = entity.album ?? ""
+        self.artist = entity.artist ?? ""
+        self.genre = entity.genre ?? ""
+        self.id = Int(entity.id)
+        self.streamUrl = entity.streamUrl ?? ""
+        self.thumbnailData = entity.thumbnailData
+    }
 }


### PR DESCRIPTION
### 작업
---
- fetchedResults 삭제 (동기화의 어려움)
- 모든 파라미터와 반환값은 `SongModel`로 통일했습니다.

> 모든 곡 가져오는 메소드
```swift
func fetchSongData() -> [SongModel] {
    let request = Song.fetchRequest()
    let sortedByDateDesc = NSSortDescriptor(key: "insertDate", ascending: false)
    request.sortDescriptors = [sortedByDateDesc]

    do {
        let songList = try mainContext.fetch(request)
        return songList.map { $0.toModel() }
    } catch {
        print(error)
    }

    return []
}
```

> 곡을 삭제하는 메소드
```swift
func deleteSongData(to song: SongModel) {
    let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "Song")
    fetchRequest.predicate = NSPredicate(format: "id == %ld", song.id)
    fetchRequest.fetchLimit = 1

    do {
        if let results = try mainContext.fetch(fetchRequest) as? [NSManagedObject], let deletedSong = results.first {
            deleteImageFile(fileName: String(song.id) + ".jpg")
            mainContext.delete(deletedSong)
            saveContext()
        }
    } catch {
        print(error)
    }
}
```

> 아래는 `SongModel` 객체에서 생성자를 추가했습니다.
```swift
/// 코어데이터 Song 엔티티를 SongModel 객체로 변환합니다.
/// - Parameter entity: Song Entity를 받습니다.
init(from entity: Song) {
    self.title = entity.title ?? ""
    self.album = entity.album ?? ""
    self.artist = entity.artist ?? ""
    self.genre = Genre(rawValue: entity.genre ?? "")
    self.id = Int(entity.id)
    self.streamUrl = entity.streamUrl ?? ""
    self.thumbnailData = entity.thumbnailData
}
```

