### PR TITLE
Fix: 메인화면 재생바 멈춤 및 버튼 동작 안하는 버그 수정

### DIFF
--- a/RandomMusic/RandomMusic/Manager/PlayerManager.swift
+++ b/RandomMusic/RandomMusic/Manager/PlayerManager.swift
@@ -27,18 +27,18 @@ final class PlayerManager {
 
     // MARK: - Callbacks
 
-    var onTimeUpdate: ((Double) -> Void)?
-    var onPlaybackFinished: (() -> Void)?
-    var onPlayStateChanged: ((Bool) -> Void)?
-    var onSongChanged: (() -> Void)?
-    var onNeedNewSong: (() -> Void)?
+    var onTimeUpdateToMainView: ((Double) -> Void)?
+    var onTimeUpdateToPlaylistView: ((Double) -> Void)?
+    var onPlayStateChangedToMainView: ((Bool) -> Void)?
+    var onPlayStateChangedToPlaylistView: ((Bool) -> Void)?
+    var onSongChanged: (() -> Void)? // Main에서만 사용 중
+    var onNeedNewSong: (() -> Void)? // Main에서만 사용 중
+    var onFeedbackChanged: ((FeedbackType) -> Void)? // Main에서만 사용 중
     var onRemote: ((SongModel?) -> Void)?
-    var onFeedbackChanged: ((FeedbackType) -> Void)?
 
     private init() {}
 
     // MARK: - Playlist Management
-
     func setPlaylist(_ value: [SongModel]) {
         playlist = value
     }
@@ -48,7 +48,6 @@ final class PlayerManager {
     }
 
     // MARK: - Feedback Management
-
     /// 현재 곡의 피드백 상태를 가져옵니다.
     func getCurrentSongFeedback() -> FeedbackType {
         guard let currentSong = currentSong else { return .none }
@@ -245,7 +244,8 @@ final class PlayerManager {
 
     private func updatePlayingState(_ playing: Bool) {
         isPlaying = playing
-        onPlayStateChanged?(playing)
+        onPlayStateChangedToMainView?(playing)
+        onPlayStateChangedToPlaylistView?(playing)
     }
 
     /// 재생 시간 정보를 주기적으로 업데이트합니다.
@@ -254,9 +254,11 @@ final class PlayerManager {
             forInterval: CMTime(seconds: 1, preferredTimescale: 1),
             queue: .main
         ) { [weak self] time in
+            guard let self = self else { return }
             let seconds = CMTimeGetSeconds(time)
-            self?.onTimeUpdate?(seconds)
-            self?.onRemote?(self?.currentSong)
+            onTimeUpdateToMainView?(seconds)
+            onTimeUpdateToPlaylistView?(seconds)
+            onRemote?(currentSong)
         }
     }
 

--- a/RandomMusic/RandomMusic/View/ViewController/Main/MainViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/Main/MainViewController.swift
@@ -67,9 +67,9 @@ class MainViewController: UIViewController {
 
     /// AVPlayer의 시간 업데이트 및 재생 완료 콜백을 바인딩합니다.
     private func bindPlayerCallbacks() {
-        PlayerManager.shared.onTimeUpdate = updateProgressUI
+        PlayerManager.shared.onTimeUpdateToMainView = updateProgressUI
 
-        PlayerManager.shared.onPlayStateChanged = { [weak self] isPlaying in
+        PlayerManager.shared.onPlayStateChangedToMainView = { [weak self] isPlaying in
             self?.updatePlayPauseButton()
         }
 

--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
@@ -109,7 +109,7 @@ class PlayListViewController: UIViewController {
     
     /// ProgressView Update
     private func updateProgressView() {
-        PlayerManager.shared.onTimeUpdate = { [weak self] seconds in
+        PlayerManager.shared.onTimeUpdateToPlaylistView = { [weak self] seconds in
             guard let self = self, let duration = self.duration, duration > 0 else { return }
             let progress = Float(seconds / duration)
             DispatchQueue.main.async {
@@ -119,7 +119,7 @@ class PlayListViewController: UIViewController {
     }
     
     private func collbakcFunc() {
-        PlayerManager.shared.onPlayStateChanged = { [weak self] isPlaying in
+        PlayerManager.shared.onPlayStateChangedToPlaylistView = { [weak self] isPlaying in
             self?.setPlayPauseButton()
         }
         
@@ -127,6 +127,11 @@ class PlayListViewController: UIViewController {
             self?.duration = seconds
             self?.updateProgressView()
         }
+    }
+
+    deinit {
+        PlayerManager.shared.onTimeUpdateToPlaylistView = nil
+        PlayerManager.shared.onPlayStateChangedToPlaylistView = nil
     }
 }
 


### PR DESCRIPTION
## 작업
---

### 메인화면 및 플레이리스트화면 멈추는 버그

아래의 클로저를 두 개의 뷰가 사용해서 생기는 버그였습니다.
```swift
var onTimeUpdate: ((Double) -> Void)?
var onPlayStateChanged: ((Bool) -> Void)?
```

```swift
// MainView
PlayerManager.shared.onTimeUpdate = updateProgressUI
```

```swift
// PlaylistView
PlayerManager.shared.onTimeUpdate = ...
```

위와 같은 상황에서 `onTimeUpdate` 클로저의 주소가 변경됩니다. `MainView` -> `PlaylistView`

PlayerManager를 싱글톤으로 사용하고 두개의 뷰가 공유하다보니 해당 문제가 발생해서 유의해야 할 거 같습니다.

![image](https://github.com/user-attachments/assets/edc3c23d-4446-4ef9-9679-ab7db522324d)
다음과 같이 사용하는 뷰에 따라서 변수를 나눴습니다.

콜백받는 상황일 때 다른 뷰가 해당 변수를 사용하고 있는지 체크해보시는 것이 좋을 거 같습니다🙂
![image](https://github.com/user-attachments/assets/d0363994-82e6-4134-8035-c947f96bee5b)

현재 어떤 뷰에서 사용하고 있는지 주석으로 표시해뒀습니다!
