### PR TITLE
Fix: 플레이리스트 진행바 관련 버그 수정

### DIFF
--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
@@ -13,17 +13,19 @@ class PlayListViewController: UIViewController {
     let playConfig = UIImage.SymbolConfiguration(pointSize: 50, weight: .regular, scale: .large)
     let backforConfig = UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .large)
     var playImage: UIImage?
-    var duration: Double?
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        playProgressView.progress = 0.0
+    }
+
+    override func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
         setButtonUI()
         bindPlayerCallbacks()
-        playProgressView.progress = 0
     }
 
     /// 재생, 이전곡, 다음곡 버튼 UI Setting
-    @MainActor
     private func setButtonUI() {
         let backImage = UIImage(systemName: "backward.frame.fill", withConfiguration: backforConfig)
         let forImage = UIImage(systemName: "forward.frame.fill", withConfiguration: backforConfig)
@@ -48,13 +50,11 @@ class PlayListViewController: UIViewController {
             self?.setPlayPauseButton()
         }
 
-        PlayerManager.shared.loadDuration { [weak self] seconds in
-            self?.duration = seconds
-        }
-
         PlayerManager.shared.onTimeUpdateToPlaylistView = { [weak self] seconds in
-            guard let self = self, let duration = self.duration, duration > 0 else { return }
+            guard let self = self else { return }
+            guard let duration = PlayerManager.shared.player?.currentItem?.duration.seconds else { return }
             let progress = Float(seconds / duration)
+            print(progress)
             DispatchQueue.main.async {
                 self.playProgressView.progress = progress
             }

--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
@@ -12,11 +12,9 @@ class PlayListViewController: UIViewController {
     /// 재생, 이전곡, 다음곡 버튼 UIImage Symbol size
     let playConfig = UIImage.SymbolConfiguration(pointSize: 50, weight: .regular, scale: .large)
     let backforConfig = UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .large)
-    var playImage: UIImage?
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        playProgressView.progress = 0.0
     }
 
     override func viewIsAppearing(_ animated: Bool) {
@@ -38,7 +36,7 @@ class PlayListViewController: UIViewController {
 
     /// 재생/일시정지 버튼 UI
     private func setPlayPauseButton() {
-        playImage = PlayerManager.shared.isPlaying ?
+        let playImage = PlayerManager.shared.isPlaying ?
                         UIImage(systemName: "pause.circle", withConfiguration: playConfig) :
                         UIImage(systemName: "play.circle.fill", withConfiguration: playConfig)
         playButton.setImage(playImage, for: .normal)
@@ -51,13 +49,8 @@ class PlayListViewController: UIViewController {
         }
 
         PlayerManager.shared.onTimeUpdateToPlaylistView = { [weak self] seconds in
-            guard let self = self else { return }
-            guard let duration = PlayerManager.shared.player?.currentItem?.duration.seconds else { return }
-            let progress = Float(seconds / duration)
-            print(progress)
-            DispatchQueue.main.async {
-                self.playProgressView.progress = progress
-            }
+            guard let duration = PlayerManager.shared.player?.currentItem?.duration.seconds, !duration.isNaN else { return }
+            self?.playProgressView.progress = Float(seconds / duration)
         }
 
         PlayerManager.shared.onPlayList = { [weak self] in


### PR DESCRIPTION
## 작업
---
메인 화면에서 퍼즈한 상태에서 플레이리스트를 띄우면 진행바가 초기화되지 않는 버그가 있었습니다.
화면이 처음 등장할 때 현재 진행바를 초기화할 필요가 있다고 판단하여 `didSet` 을 활용하여 초기화했습니다.
```swift
var onTimeUpdateToPlaylistView: ((Double) -> Void)? {
    didSet { onTimeUpdateToPlaylistView?(playBackTime ?? 0.0) }
}
```

### 추가 작업
> PlayerManager에 해당 변수를 추가했습니다.
```swift
private(set) var playBackTime: Double? // 스트리밍 중인 음악 진행 시간
```

> UI가 백그라운드 쓰레드에서 그려지는 버그를 수정했습니다.
```swift
Task { @MainActor in
    onSongChanged?()
    play()
}
```

> 버그를 수행하면서 PlaylistView의 불필요한 변수를 제거했습니다.
```swift
var playImage: UIImage? // 제거
var duration: Double? // 제거
```

> PlaylistView에 더이상 `loadDuration()` 메소드가 필요하지 않아서 삭제했습니다.