### PR TITLE
refactor: 슬라이더를 좀 더 부드럽게 이동

### DIFF
--- a/RandomMusic/RandomMusic/View/ViewController/Main/Base.lproj/Main.storyboard
+++ b/RandomMusic/RandomMusic/View/ViewController/Main/Base.lproj/Main.storyboard
@@ -25,18 +25,18 @@
                                         <rect key="frame" x="0.0" y="0.0" width="393" height="714"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="KkE-tO-Z9x">
-                                                <rect key="frame" x="20" y="0.0" width="353" height="60.666666666666664"/>
+                                                <rect key="frame" x="20" y="0.0" width="353" height="50.666666666666664"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c3c-t7-BjU">
-                                                        <rect key="frame" x="0.0" y="0.0" width="49.333333333333336" height="60.666666666666664"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="49.333333333333336" height="50.666666666666664"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" image="hand.thumbsdown" catalog="system"/>
                                                         <connections>
                                                             <action selector="dislikeTapped:" destination="oUJ-Ad-HvN" eventType="touchUpInside" id="hC1-wS-cFf"/>
                                                         </connections>
                                                     </button>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="I4Y-Df-CdZ">
-                                                        <rect key="frame" x="69.333333333333329" y="0.0" width="214.33333333333337" height="60.666666666666664"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="I4Y-Df-CdZ">
+                                                        <rect key="frame" x="69.333333333333329" y="0.0" width="214.33333333333337" height="50.666666666666664"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2ip-Z0-yWx">
                                                                 <rect key="frame" x="0.0" y="0.0" width="214.33333333333334" height="20.333333333333332"/>
@@ -45,7 +45,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Singer" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i0s-Ti-8Zv">
-                                                                <rect key="frame" x="0.0" y="40.333333333333343" width="214.33333333333334" height="20.333333333333329"/>
+                                                                <rect key="frame" x="0.0" y="30.333333333333343" width="214.33333333333334" height="20.333333333333329"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -53,7 +53,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9BL-K8-pry">
-                                                        <rect key="frame" x="303.66666666666669" y="0.0" width="49.333333333333314" height="60.666666666666664"/>
+                                                        <rect key="frame" x="303.66666666666669" y="0.0" width="49.333333333333314" height="50.666666666666664"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" image="hand.thumbsup" catalog="system"/>
                                                         <connections>
@@ -63,13 +63,13 @@
                                                 </subviews>
                                             </stackView>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zyz-oi-m8T">
-                                                <rect key="frame" x="60" y="100.66666666666666" width="273" height="273"/>
+                                                <rect key="frame" x="60" y="93.333333333333343" width="273" height="273"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="zyz-oi-m8T" secondAttribute="height" multiplier="1:1" id="mbS-4V-ZHA"/>
                                                 </constraints>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="uqY-cv-jzx">
-                                                <rect key="frame" x="20" y="413.66666666666663" width="353" height="30"/>
+                                                <rect key="frame" x="20" y="408.66666666666663" width="353" height="30"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="1000" text="00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yTE-gk-zc6">
                                                         <rect key="frame" x="0.0" y="0.0" width="46" height="30"/>
@@ -79,9 +79,6 @@
                                                     </label>
                                                     <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="8fY-R8-EKh">
                                                         <rect key="frame" x="54" y="0.0" width="245" height="31"/>
-                                                        <connections>
-                                                            <action selector="sliderValueChanged:" destination="oUJ-Ad-HvN" eventType="valueChanged" id="eAK-6P-OpG"/>
-                                                        </connections>
                                                     </slider>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="1000" text="00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEQ-TE-RTd">
                                                         <rect key="frame" x="307" y="0.0" width="46" height="30"/>
@@ -92,7 +89,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="idR-k5-etR">
-                                                <rect key="frame" x="20" y="483.66666666666663" width="353" height="34.333333333333371"/>
+                                                <rect key="frame" x="20" y="481.33333333333337" width="353" height="34.333333333333371"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IGc-Tg-0S2">
                                                         <rect key="frame" x="0.0" y="0.0" width="49.666666666666664" height="34.333333333333336"/>


### PR DESCRIPTION
## 문제
사용자가 메인화면 슬라이더를 드래그하면
사용자가 이동하려는 위치와 PlayerManager에서 `seek()`로 이동하려는 위치가 맞지 않아
드래그하는 도중에 옆으로 튀는 문제가 있습니다.

## 해결
`isSliderDragging` 이라는 플래그를 기준으로 드래그가 종료되었을 때만 `seek()`를 실행합니다.
드래그 중에는 현재 시간 UI를 계속 업데이트합니다.

---

> [!NOTE]
>  그 외 변경사항은 함수 분리와 DocC 추가 작업입니다.