### PR TITLE
Feat: 조건에 따라 이전 곡으로 스킵하도록 변경

### DIFF
--- a/RandomMusic/RandomMusic/Manager/PlayerManager.swift
+++ b/RandomMusic/RandomMusic/Manager/PlayerManager.swift
@@ -212,6 +212,11 @@ final class PlayerManager {
             return
         }
 
+        guard let playBackTime, playBackTime < 3.0 else {
+            play()
+            return
+        }
+
         setCurrentIndex(currentIndex - 1)
         onSongChanged?()
         play()


### PR DESCRIPTION
### 작업
---
이전 곡으로 스킵할 때 현재 곡이 `3`초가 지났다면 다시 `0`초로 변경하도록 기능을 추가했습니다.

```swift
guard let playBackTime, playBackTime < 3.0 else {
    play()
    return
}