### PR TITLE
chore: 아이폰은 세로만 지원

### DIFF
--- a/RandomMusic/RandomMusic/Info.plist
+++ b/RandomMusic/RandomMusic/Info.plist
@@ -6,10 +6,6 @@
 	<string>$(NAME)</string>
 	<key>TOKEN</key>
 	<string>$(TOKEN)</string>
-    <key>UIBackgroundModes</key>
-    <array>
-        <string>audio</string>
-    </array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -29,5 +25,9 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
아이폰 세로, 아이패드 가로/세로 만 지원하도록 변경하였습니다.