### PR TITLE
Feat: 장르별로 한 번에 음악 여러 개를 추가할 수 있는 기능

### DIFF
--- a/RandomMusic/RandomMusic/Enum/Genre.swift
+++ b/RandomMusic/RandomMusic/Enum/Genre.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 /// 장르
 enum Genre: String, CaseIterable, Codable {
@@ -18,6 +18,23 @@ enum Genre: String, CaseIterable, Codable {
         case "RnB": self = .rnb
         case "Hiphop": self = .hiphop
         default: self = .pop
+        }
+    }
+
+    var color: UIColor {
+        switch self {
+        case .classic:
+            return .purple
+        case .hiphop:
+            return .orange
+        case .jazz:
+            return .green
+        case .pop:
+            return .systemPink
+        case .rnb:
+            return .blue
+        case .rock:
+            return .red
         }
     }
 }

--- a/RandomMusic/RandomMusic/Manager/PlayerManager.swift
+++ b/RandomMusic/RandomMusic/Manager/PlayerManager.swift
@@ -138,7 +138,8 @@ final class PlayerManager {
     func addSongs(genre: Genre) {
         Task {
             let songs = try await songService.getMusics(genre: genre)
-			dump(songs)
+            songs.forEach { DataManager.shared.insertSongData(from: $0) }
+            playlist.append(contentsOf: songs)
         }
     }
 

--- a/RandomMusic/RandomMusic/Manager/PlayerManager.swift
+++ b/RandomMusic/RandomMusic/Manager/PlayerManager.swift
@@ -134,8 +134,9 @@ final class PlayerManager {
         onSongChangedToPlaylistView?()
     }
 
-    // TODO: 작업
-    func addSongs(genre: Genre) {
+    /// 장르별로 10곡을 추가합니다.
+    /// - Parameter genre: 장르를 받습니다.
+    func addSongs(from genre: Genre) {
         Task {
             let songs = try await songService.getMusics(genre: genre)
             songs.forEach { DataManager.shared.insertSongData(from: $0) }

--- a/RandomMusic/RandomMusic/Manager/PlayerManager.swift
+++ b/RandomMusic/RandomMusic/Manager/PlayerManager.swift
@@ -134,6 +134,14 @@ final class PlayerManager {
         onSongChangedToPlaylistView?()
     }
 
+    // TODO: 작업
+    func addSongs(genre: Genre) {
+        Task {
+            let songs = try await songService.getMusics(genre: genre)
+			dump(songs)
+        }
+    }
+
     /// 랜덤 곡을 가져와서 플레이리스트에 추가합니다.
     func addRandomSong() async {
         do {

--- a/RandomMusic/RandomMusic/Manager/RemoteManager.swift
+++ b/RandomMusic/RandomMusic/Manager/RemoteManager.swift
@@ -44,7 +44,7 @@ final class RemoteManager {
         }
 
         commandCenter.previousTrackCommand.addTarget { [weak self] _ in
-            self?.playerManager.moveBackward()
+            _ = self?.playerManager.moveBackward()
             return .success
         }
 

--- a/RandomMusic/RandomMusic/Service/Song/SongService.swift
+++ b/RandomMusic/RandomMusic/Service/Song/SongService.swift
@@ -54,7 +54,10 @@ class SongService {
         return songModel
     }
 
-    // TODO: 작업
+    // MARK: 추가된 메소드입니다. (장르별 10곡)
+    /// 장르별로 10곡을 가져오는 메소드입니다.
+    /// - Parameter genre: 선택된 장르를 받습니다.
+    /// - Returns: 해당 장르의 10곡을 반환합니다.
     func getMusics(genre: Genre? = nil) async throws -> [SongModel] {
         var realGenre: Genre
 

--- a/RandomMusic/RandomMusic/Service/Song/SongService.swift
+++ b/RandomMusic/RandomMusic/Service/Song/SongService.swift
@@ -71,7 +71,7 @@ class SongService {
             var thumbnailData: Data? = nil
 
             if response.thumbnail == .exists {
-                let thumbnailData = try await fetchThumbnailImage(from: response.streamUrl)
+                thumbnailData = try await fetchThumbnailImage(from: response.streamUrl)
             }
 
             songModelList.append(SongModel(from: response, thumbnailData: thumbnailData))

--- a/RandomMusic/RandomMusic/Service/Song/SongService.swift
+++ b/RandomMusic/RandomMusic/Service/Song/SongService.swift
@@ -54,6 +54,32 @@ class SongService {
         return songModel
     }
 
+    // TODO: 작업
+    func getMusics(genre: Genre? = nil) async throws -> [SongModel] {
+        var realGenre: Genre
+
+        if let genre {
+            realGenre = genre
+        } else {
+            let pm = PreferenceManager()
+            realGenre = pm.selectRandomGenre()
+        }
+
+        let responseList = try await fetchRandomMusics(genre: realGenre)
+        var songModelList: [SongModel] = []
+        for	response in responseList {
+            var thumbnailData: Data? = nil
+
+            if response.thumbnail == .exists {
+                let thumbnailData = try await fetchThumbnailImage(from: response.streamUrl)
+            }
+
+            songModelList.append(SongModel(from: response, thumbnailData: thumbnailData))
+        }
+
+        return songModelList
+    }
+
     /// 헤더가 포함된 Asset 생성
     func createAssetWithHeaders(url: String) throws -> AVURLAsset? {
         let request = try networkService.makeRequest(endpoint: url)
@@ -68,6 +94,15 @@ class SongService {
     /// - Returns: api 응답형식. SongModel 로 변환 후 사용해야함
     private func fetchRandomMusic(genre: Genre? = nil) async throws -> SongResponse {
         var endpoint = "/api/music/random"
+        if let genre = genre {
+            endpoint += "?genre=\(genre.rawValue)"
+        }
+
+        return try await networkService.fetch(endpoint: endpoint)
+    }
+
+    private func fetchRandomMusics(genre: Genre? = nil) async throws -> [SongResponse] {
+        var endpoint = "/api/music/randomMany/10"
         if let genre = genre {
             endpoint += "?genre=\(genre.rawValue)"
         }

--- a/RandomMusic/RandomMusic/View/Cell/CategoryCell.swift
+++ b/RandomMusic/RandomMusic/View/Cell/CategoryCell.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 class CategoryCell: UICollectionViewCell {
-
     @IBOutlet weak var mainView: UIView!
     @IBOutlet weak var mainLabel: UILabel!
 

--- a/RandomMusic/RandomMusic/View/Cell/CategoryCell.swift
+++ b/RandomMusic/RandomMusic/View/Cell/CategoryCell.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+class CategoryCell: UICollectionViewCell {
+    @IBOutlet weak var categoryButton: UIButton!
+
+    var genre: Genre?
+
+    func configureUI(with genre: Genre) {
+        self.genre = genre
+        categoryButton.setTitle(genre.rawValue, for: .normal)
+        categoryButton.layer.cornerRadius = categoryButton.frame.height / 2
+        categoryButton.layer.borderWidth = 1
+        categoryButton.layer.borderColor = UIColor.red.cgColor
+    }
+}

--- a/RandomMusic/RandomMusic/View/Cell/CategoryCell.swift
+++ b/RandomMusic/RandomMusic/View/Cell/CategoryCell.swift
@@ -1,15 +1,17 @@
 import UIKit
 
 class CategoryCell: UICollectionViewCell {
-    @IBOutlet weak var categoryButton: UIButton!
+
+    @IBOutlet weak var mainView: UIView!
+    @IBOutlet weak var mainLabel: UILabel!
 
     var genre: Genre?
 
     func configureUI(with genre: Genre) {
         self.genre = genre
-        categoryButton.setTitle(genre.rawValue, for: .normal)
-        categoryButton.layer.cornerRadius = categoryButton.frame.height / 2
-        categoryButton.layer.borderWidth = 1
-        categoryButton.layer.borderColor = UIColor.red.cgColor
+        mainLabel.text = "+ \(genre.rawValue)"
+        mainView.layer.cornerRadius = mainView.frame.height / 2
+        mainView.layer.borderWidth = 1
+        mainView.layer.borderColor = genre.color.cgColor
     }
 }

--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListView.storyboard
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListView.storyboard
@@ -151,7 +151,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="75" height="34.333333333333336"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B6B-xD-1Y9">
+                                                <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B6B-xD-1Y9">
                                                     <rect key="frame" x="0.0" y="0.0" width="75" height="34.333333333333336"/>
                                                     <inset key="contentEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
                                                     <inset key="titleEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>

--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListView.storyboard
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListView.storyboard
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eLK-HM-NZt">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eLK-HM-NZt">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -72,7 +73,7 @@
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="ad3-hD-kng">
-                                <rect key="frame" x="0.0" y="162" width="393" height="570"/>
+                                <rect key="frame" x="0.0" y="153" width="393" height="579"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SongTableViewCell" id="ntD-lu-3Gm" customClass="SongTableViewCell" customModule="RandomMusic" customModuleProvider="target">
@@ -130,17 +131,66 @@
                                     <outlet property="delegate" destination="Y6W-OH-hqX" id="d9I-Gg-O7h"/>
                                 </connections>
                             </tableView>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="HqW-tb-mRZ">
+                                <rect key="frame" x="0.0" y="103" width="393" height="50"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="Z6I-M8-mL1"/>
+                                </constraints>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="gEm-8B-nwN">
+                                    <size key="itemSize" width="86" height="40"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CategoryCell" id="8So-lK-BhF" customClass="CategoryCell" customModule="RandomMusic" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="75" height="34.333333333333336"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Nxe-NG-Lmf">
+                                            <rect key="frame" x="0.0" y="0.0" width="75" height="34.333333333333336"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B6B-xD-1Y9">
+                                                    <rect key="frame" x="0.0" y="0.0" width="75" height="34.333333333333336"/>
+                                                    <inset key="contentEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
+                                                    <inset key="titleEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
+                                                    <inset key="imageEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
+                                                    <state key="normal" title="Button"/>
+                                                    <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="B6B-xD-1Y9" secondAttribute="bottom" id="2QB-dz-Nwi"/>
+                                                <constraint firstItem="B6B-xD-1Y9" firstAttribute="leading" secondItem="Nxe-NG-Lmf" secondAttribute="leading" id="LmI-Od-gjT"/>
+                                                <constraint firstAttribute="trailing" secondItem="B6B-xD-1Y9" secondAttribute="trailing" id="dNa-tC-7M7"/>
+                                                <constraint firstItem="B6B-xD-1Y9" firstAttribute="top" secondItem="Nxe-NG-Lmf" secondAttribute="top" id="dsf-dl-ST2"/>
+                                            </constraints>
+                                        </collectionViewCellContentView>
+                                        <connections>
+                                            <outlet property="categoryButton" destination="B6B-xD-1Y9" id="j2H-94-uk2"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                </cells>
+                                <connections>
+                                    <outlet property="dataSource" destination="Y6W-OH-hqX" id="HIO-oV-Ach"/>
+                                    <outlet property="delegate" destination="Y6W-OH-hqX" id="ubB-2K-EUd"/>
+                                </connections>
+                            </collectionView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="uxS-el-Qhh" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="814-n7-boI"/>
                             <constraint firstItem="ad3-hD-kng" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="8T4-0k-AHp"/>
+                            <constraint firstItem="HqW-tb-mRZ" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="Er5-rI-lAz"/>
+                            <constraint firstItem="HqW-tb-mRZ" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="J1L-lp-dwR"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="HqW-tb-mRZ" secondAttribute="trailing" id="JUW-yy-THI"/>
                             <constraint firstItem="uxS-el-Qhh" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="KDD-Y1-OhS"/>
                             <constraint firstItem="ad3-hD-kng" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="OTB-vg-rRo"/>
                             <constraint firstAttribute="bottom" secondItem="uxS-el-Qhh" secondAttribute="bottom" id="XGO-QG-YZ6"/>
-                            <constraint firstItem="ad3-hD-kng" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="qbu-ib-nH2"/>
-                            <constraint firstItem="uxS-el-Qhh" firstAttribute="top" secondItem="ad3-hD-kng" secondAttribute="bottom" id="wrA-Od-cGe"/>
+                            <constraint firstItem="ad3-hD-kng" firstAttribute="top" secondItem="HqW-tb-mRZ" secondAttribute="bottom" id="jCL-Dm-8VM"/>
+                            <constraint firstItem="uxS-el-Qhh" firstAttribute="top" secondItem="ad3-hD-kng" secondAttribute="bottom" id="kjZ-8Z-vqT"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Playlist" id="Paf-uj-sfr">
@@ -153,6 +203,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="backButton" destination="dQo-7a-B3E" id="PdY-CK-rmE"/>
+                        <outlet property="collectionView" destination="HqW-tb-mRZ" id="9hV-nd-dpq"/>
                         <outlet property="forButton" destination="mrz-yj-NHT" id="TmM-zp-BGY"/>
                         <outlet property="playButton" destination="VLJ-GC-UZL" id="YNN-Mw-E2R"/>
                         <outlet property="playListTableView" destination="ad3-hD-kng" id="KVm-5d-fNm"/>
@@ -169,7 +220,7 @@
                 <navigationController storyboardIdentifier="PlayListView" title="PlayListView" automaticallyAdjustsScrollViewInsets="NO" id="eLK-HM-NZt" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="j5f-by-1bS">
-                        <rect key="frame" x="0.0" y="118" width="393" height="44"/>
+                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListView.storyboard
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListView.storyboard
@@ -145,30 +145,41 @@
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CategoryCell" id="8So-lK-BhF" customClass="CategoryCell" customModule="RandomMusic" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="75" height="34.333333333333336"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="61.333333333333343" height="30.333333333333332"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Nxe-NG-Lmf">
-                                            <rect key="frame" x="0.0" y="0.0" width="75" height="34.333333333333336"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="61.333333333333343" height="30.333333333333332"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B6B-xD-1Y9">
-                                                    <rect key="frame" x="0.0" y="0.0" width="75" height="34.333333333333336"/>
-                                                    <inset key="contentEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
-                                                    <inset key="titleEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
-                                                    <inset key="imageEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
-                                                    <state key="normal" title="Button"/>
-                                                    <buttonConfiguration key="configuration" style="plain" title="Button"/>
-                                                </button>
+                                                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f3E-Ti-CLb">
+                                                    <rect key="frame" x="0.0" y="0.0" width="61.333333333333336" height="30.333333333333332"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lzJ-cv-tdV">
+                                                            <rect key="frame" x="10" y="5" width="41.333333333333336" height="20.333333333333332"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="trailing" secondItem="lzJ-cv-tdV" secondAttribute="trailing" constant="10" id="86n-pL-ODZ"/>
+                                                        <constraint firstAttribute="bottom" secondItem="lzJ-cv-tdV" secondAttribute="bottom" constant="5" id="PHm-B8-YOz"/>
+                                                        <constraint firstItem="lzJ-cv-tdV" firstAttribute="leading" secondItem="f3E-Ti-CLb" secondAttribute="leading" constant="10" id="YhN-p2-2bp"/>
+                                                        <constraint firstItem="lzJ-cv-tdV" firstAttribute="top" secondItem="f3E-Ti-CLb" secondAttribute="top" constant="5" id="s8w-0D-b6Z"/>
+                                                    </constraints>
+                                                </view>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="B6B-xD-1Y9" secondAttribute="bottom" id="2QB-dz-Nwi"/>
-                                                <constraint firstItem="B6B-xD-1Y9" firstAttribute="leading" secondItem="Nxe-NG-Lmf" secondAttribute="leading" id="LmI-Od-gjT"/>
-                                                <constraint firstAttribute="trailing" secondItem="B6B-xD-1Y9" secondAttribute="trailing" id="dNa-tC-7M7"/>
-                                                <constraint firstItem="B6B-xD-1Y9" firstAttribute="top" secondItem="Nxe-NG-Lmf" secondAttribute="top" id="dsf-dl-ST2"/>
+                                                <constraint firstItem="f3E-Ti-CLb" firstAttribute="leading" secondItem="Nxe-NG-Lmf" secondAttribute="leading" id="gQa-VV-Z4T"/>
+                                                <constraint firstAttribute="bottom" secondItem="f3E-Ti-CLb" secondAttribute="bottom" id="k0v-9H-6Go"/>
+                                                <constraint firstItem="f3E-Ti-CLb" firstAttribute="top" secondItem="Nxe-NG-Lmf" secondAttribute="top" id="ueG-iL-Vj9"/>
+                                                <constraint firstAttribute="trailing" secondItem="f3E-Ti-CLb" secondAttribute="trailing" id="w1A-KE-p3u"/>
                                             </constraints>
                                         </collectionViewCellContentView>
                                         <connections>
-                                            <outlet property="categoryButton" destination="B6B-xD-1Y9" id="j2H-94-uk2"/>
+                                            <outlet property="mainLabel" destination="lzJ-cv-tdV" id="bsV-zD-T23"/>
+                                            <outlet property="mainView" destination="f3E-Ti-CLb" id="b8m-Vz-OdF"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>

--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
@@ -177,6 +177,7 @@ extension PlayListViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: String(describing: CategoryCell.self), for: indexPath) as! CategoryCell
         cell.configureUI(with: Genre.allCases[indexPath.item])
+
         return cell
     }
 }
@@ -184,12 +185,17 @@ extension PlayListViewController: UICollectionViewDataSource {
 extension PlayListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if let cell = collectionView.cellForItem(at: indexPath) as? CategoryCell {
-            // 해당 장르를 사용해서 10곡을 추가하는 것을 PlayerManager에게 보낸다.
-            // PlayerManager는 이것을 통해서 NetworkManager에 호출한다.
-            // 추가된 곡은 playlist에 추가한다.
             if let genre = cell.genre {
-                PlayerManager.shared.addSongs(genre: genre)
+                PlayerManager.shared.addSongs(from: genre)
             }
         }
+    }
+}
+
+extension PlayListViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
     }
 }

--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 
 class PlayListViewController: UIViewController {
     @IBOutlet weak var playListTableView: UITableView!
+    @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var playProgressView: UIProgressView!
     @IBOutlet weak var backButton: UIButton!
     @IBOutlet weak var playButton: UIButton!
@@ -16,12 +17,12 @@ class PlayListViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        setButtonUI()
+        setConfigureUI()
         bindPlayerCallbacks()
     }
 
     /// 재생, 이전곡, 다음곡 버튼 UI Setting
-    private func setButtonUI() {
+    private func setConfigureUI() {
         let backImage = UIImage(systemName: "backward.frame.fill", withConfiguration: backforConfig)
         let forImage = UIImage(systemName: "forward.frame.fill", withConfiguration: backforConfig)
 
@@ -29,6 +30,12 @@ class PlayListViewController: UIViewController {
         forButton.setImage(forImage, for: .normal)
 
         setPlayPauseButton()
+
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.scrollDirection = .horizontal
+        flowLayout.minimumInteritemSpacing = 30
+        flowLayout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+        collectionView.collectionViewLayout = flowLayout
     }
 
     /// 재생/일시정지 버튼 UI
@@ -158,5 +165,23 @@ extension PlayListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         PlayerManager.shared.setCurrentIndex(indexPath.row)
         PlayerManager.shared.play()
+    }
+}
+
+extension PlayListViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return Genre.allCases.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: String(describing: CategoryCell.self), for: indexPath) as! CategoryCell
+        cell.configureUI(with: Genre.allCases[indexPath.item])
+        return cell
+    }
+}
+
+extension PlayListViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
     }
 }

--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
@@ -168,6 +168,7 @@ extension PlayListViewController: UITableViewDelegate {
     }
 }
 
+// MARK: - CollectionView Delegate
 extension PlayListViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return Genre.allCases.count
@@ -182,6 +183,13 @@ extension PlayListViewController: UICollectionViewDataSource {
 
 extension PlayListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
+        if let cell = collectionView.cellForItem(at: indexPath) as? CategoryCell {
+            // 해당 장르를 사용해서 10곡을 추가하는 것을 PlayerManager에게 보낸다.
+            // PlayerManager는 이것을 통해서 NetworkManager에 호출한다.
+            // 추가된 곡은 playlist에 추가한다.
+            if let genre = cell.genre {
+                PlayerManager.shared.addSongs(genre: genre)
+            }
+        }
     }
 }


### PR DESCRIPTION
## 작업
---
![image](https://github.com/user-attachments/assets/bf74ac68-2b21-4b8b-b93f-d8f86af0bc5a)

- `PlaylistVC`의 뷰에 컬렉션뷰를 추가했습니다.

### SongService
> 아래와 같은 메소드를 추가했습니다. 참고해주세요!

```swift
// MARK: 추가된 메소드입니다. (장르별 10곡)
/// 장르별로 10곡을 가져오는 메소드입니다.
/// - Parameter genre: 선택된 장르를 받습니다.
/// - Returns: 해당 장르의 10곡을 반환합니다.
func getMusics(genre: Genre? = nil) async throws -> [SongModel] {
    var realGenre: Genre

    if let genre {
        realGenre = genre
    } else {
        let pm = PreferenceManager()
        realGenre = pm.selectRandomGenre()
    }

    let responseList = try await fetchRandomMusics(genre: realGenre)
    var songModelList: [SongModel] = []
    for	response in responseList {
        var thumbnailData: Data? = nil

        if response.thumbnail == .exists {
            thumbnailData = try await fetchThumbnailImage(from: response.streamUrl)
        }

        songModelList.append(SongModel(from: response, thumbnailData: thumbnailData))
    }

    return songModelList
}
```

### PlayerManager
> 다음과 같은 메소드를 추가했습니다. 참고해주세요!

```swift
/// 장르별로 10곡을 추가합니다.
/// - Parameter genre: 장르를 받습니다.
func addSongs(from genre: Genre) {
    Task {
        let songs = try await songService.getMusics(genre: genre)
        songs.forEach { DataManager.shared.insertSongData(from: $0) }
        playlist.append(contentsOf: songs)
    }
}
```

최대한 의존성 방향을 지키면서 구현했습니다.