### PR TITLE
ui: scoll 애니메이션 끊기지 않게 수정, edit button 이미지 변경

### DIFF
--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListView.storyboard
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListView.storyboard
@@ -225,7 +225,7 @@
                                 <action selector="dismissButton:" destination="Y6W-OH-hqX" id="aVP-YN-ktb"/>
                             </connections>
                         </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" title="edit" image="ellipsis" catalog="system" id="hmL-Ya-fP4">
+                        <barButtonItem key="rightBarButtonItem" image="slider.horizontal.3" catalog="system" id="hmL-Ya-fP4">
                             <color key="tintColor" systemColor="secondaryLabelColor"/>
                             <connections>
                                 <action selector="editButton:" destination="Y6W-OH-hqX" id="n1i-5R-aJN"/>
@@ -268,10 +268,10 @@
     <resources>
         <image name="backward.frame.fill" catalog="system" width="128" height="87"/>
         <image name="chevron.down" catalog="system" width="128" height="70"/>
-        <image name="ellipsis" catalog="system" width="128" height="37"/>
         <image name="forward.frame.fill" catalog="system" width="128" height="87"/>
         <image name="photo" catalog="system" width="128" height="93"/>
         <image name="play.circle.fill" catalog="system" width="128" height="123"/>
+        <image name="slider.horizontal.3" catalog="system" width="128" height="99"/>
         <namedColor name="MainColor">
             <color red="0.78799998760223389" green="0.9100000262260437" blue="0.31000000238418579" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
@@ -76,7 +76,9 @@ class PlayListViewController: UIViewController {
             Task { @MainActor in
                 self?.playListTableView.reloadData()
                 self?.setDismissImageButton()
-                try? await Task.sleep(nanoseconds: 1_000_000)
+                
+                self?.playListTableView.layoutIfNeeded()
+                try? await Task.sleep(nanoseconds: 4_000_000)
                 self?.scrollSelectPlaySong()
             }
         }
@@ -90,7 +92,9 @@ class PlayListViewController: UIViewController {
         guard index >= 0 && index < rowCount else { return }
         
         let indexPath = IndexPath(row: index, section: 0)
-        playListTableView.selectRow(at: indexPath, animated: true, scrollPosition: .middle)
+        Task { @MainActor in
+            playListTableView.selectRow(at: indexPath, animated: true, scrollPosition: .middle)
+        }
     }
     
     /// Dismiss Image Button 이미지 세팅
@@ -161,6 +165,7 @@ class PlayListViewController: UIViewController {
     /// Edit Mode로 전환되어 삭제 맟 플레이리스트 순서 변경이 가능합니다
     @IBAction func editButton(_ sender: UIBarButtonItem) {
         playListTableView.setEditing(!playListTableView.isEditing, animated: true)
+        sender.image = playListTableView.isEditing ? UIImage(systemName: "checkmark") : UIImage(systemName: "slider.horizontal.3")
     }
     
     /// dismiss 버튼, 이미지 버튼 터치


### PR DESCRIPTION
- 이전곡, 다음곡, 목록 탭하여 재생 시 발생하는 스크롤 애니메이션 끊기는 현상 수정
- edit mode 활성화: "checkmark", 비활성화: "slider.horizontal.3"