### PR TITLE
fix: 재생목록 삭제안되는 문제 수정

### DIFF
--- a/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
+++ b/RandomMusic/RandomMusic/View/ViewController/Playlist/PlayListViewController.swift
@@ -232,7 +232,6 @@ extension PlayListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
             PlayerManager.shared.removeSong(at: indexPath.row)
-            tableView.deleteRows(at: [indexPath], with: .automatic)
         }
     }
     


### PR DESCRIPTION
현재곡이 바뀌면 처리하던 Callback을 NotificationCenter로 교체하면서
해당 옵저버 동작과 테이블 자체 tableView.deleteRows() 가 겹쳐
삭제시 에러가 발생하는 부분을 수정하였습니다.